### PR TITLE
Use URL param token to populate textarea

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,14 @@ function display(str, id) {
 	}
 	document.getElementById(id).textContent = output;
 }
+
+const token = new URLSearchParams(
+		document.location.search.substring(1)
+	).get('token');
+
+if (token) {
+	display(token, 'encoded-jwt');
+}
 decodeJWT();
 		</script>
 	</body>


### PR DESCRIPTION
When the URL parameter 'token' is present in the URL, use that value to
populate the "Encoded JWT Token" textarea.

Resolves #2